### PR TITLE
Alan's feedback items

### DIFF
--- a/docs/.variables.adoc
+++ b/docs/.variables.adoc
@@ -19,7 +19,7 @@
 :content-about-missy: Melissa Arnette Elliott (born July 1, 1971) is an American rapper, singer, songwriter, and record producer.
 :content-about-pink: Alecia Beth Moore (born September 8, 1979), known professionally as Pink (stylized as P!nk), is an American singer and songwriter.
 :subs: subs="attributes+"
-:see-prev-docs: The tasks and examples in this {document} build on work done in previous {document}s (starting with xref:sandboxes[the sandboxes chapter]). If you want to follow along with the examples, make sure you're all caught up.
+:see-prev-docs: The tasks and examples in this {document} are based on work done in previous {document}s (starting with xref:sandboxes[the sandboxes chapter]). If you want to follow along with the examples, make sure you're all caught up.
 :title-setup: Setting up your development environment
 :title-sandboxes: Sandboxes
 :title-apps: App development

--- a/docs/apps.adoc
+++ b/docs/apps.adoc
@@ -48,7 +48,11 @@ src/
 <2> Contains the standard project settings, as defined by the CLI.
 <3> The main project folder. JavaScript code and assets are placed here.
 
-TIP: If you need to start your sandbox and your current working directory is an XP project directory, then the projects assigned sandbox will be started automatically.
+Each XP project is linked to one and only one sandbox. If you want to change the sandbox that a project is linked to, use the command
+
+  enonic project sandbox
+
+And select the desired sandbox.
 
 == Building and deploying
 

--- a/docs/content.adoc
+++ b/docs/content.adoc
@@ -14,6 +14,8 @@ Content types are schemas that tell XP what properties a piece of content of a p
 
 If you're used to working with databases, you can think of content types as table schemas and contents as the rows of a table. The properties are the columns specified by the schema. Similarly, a content type is much like a _(data) type_ or a _class_ in many programming languages: something that describes the shape of your data. A piece of content is a manifestation/instance of that data type. The properties of the content type specify what that data type contains.
 
+IMPORTANT: Content types belong to XP applications. If you stop or remove an application that contains a content type, you'll no longer be able to create content of that type, and rendering and previewing content of that type will not work.
+
 == Task: The {content-type-1} content type
 
 Now that we know what a content type is, let's look at how we create them and make XP recognize them. By the end of this section we'll have created a content type that gives us a simple form that would look like the screenshot below in Content Studio. We'll see how to find and fill in the form in the following sections.

--- a/docs/content.adoc
+++ b/docs/content.adoc
@@ -4,6 +4,8 @@ include::.variables.adoc[]
 
 In this {document}, we'll start working with sites and content types in XP. We'll look at how we create content and how it's stored, as well as how to create and publish sites. To achieve this, we'll start working with and getting familiar with _Content Studio_, XP's content editing suite.
 
+This {document} gives a brief introduction to Content Studio and how to use it. For a more comprehensive overview, head to the https://developer.enonic.com/docs/content-studio/stable[Content Studio reference documentation].
+
 NOTE: {see-prev-docs}
 
 == What are content types?

--- a/docs/content.adoc
+++ b/docs/content.adoc
@@ -65,7 +65,7 @@ If everything goes well, you should see your sandbox logs update now. And that's
 
 == Sites
 
-After the preceding few steps, everything is ready for us to create some actual content! So with your sandbox up and running, and navigate to {cs-url}[Content Studio]. You should be met with an empty studio that tells you you are "wasting this space":
+After the preceding few steps, everything is ready for us to create some actual content! With your sandbox up and running, navigate to {cs-url}[Content Studio]. You should be met with an empty studio that tells you are "wasting this space":
 
 .An empty content studio
 image::content-studio-empty.png[What Content Studio looks like when it's completely empty., {image-xl}]

--- a/docs/headless-api.adoc
+++ b/docs/headless-api.adoc
@@ -354,7 +354,7 @@ dependencies {
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
     xp.enonicRepo( 'dev' )
 }
 ----

--- a/docs/headless-api.adoc
+++ b/docs/headless-api.adoc
@@ -380,7 +380,7 @@ The headless starter takes care of this for us by mapping requests to an `/api` 
 ----
 
 <.> This tells XP that requests that match this mapping's pattern should be routed to the `/controllers/graphql.js` controller
-<.> This pattern tells XP that what reuqests to send to this mapping's controller. In this case, it's any requests to `<site-url>/api`, where `<site-url>` is the URL for your site.
+<.> This pattern tells XP that what requests to send to this mapping's controller. In this case, it's any requests to `<site-url>/api`, where `<site-url>` is the URL for your site.
 
 The controller takes care of generating the schema and providing the API endpoints and logic. The headless starter comes with a default controller that provides the schema and the GraphQL playground that we've been using thus for. It's too long to include in this guide, but if you want to have a look at it, the https://github.com/enonic/starter-headless/blob/master/src/main/resources/controllers/graphql.js[headless starter GraphQL controller] is available on GitHub.
 

--- a/docs/headless-api.adoc
+++ b/docs/headless-api.adoc
@@ -318,7 +318,7 @@ And find out that with our data set, there's only one:
 
 == The Guillotine library
 
-If you've been wondering how the GraphQL API we've been querying up until now was created: the Guillotine library is the answer. The Guillotine library analyzes all the content in your applications and generates an API from that. It' s an optional library that comes preconfigured with the headless starter that we used back xref:apps#_projects_and_starters[back when we first created our app in a previous {document}]. Guillotine provides direct, typed, and documented access to content within your site.
+If you've been wondering how the GraphQL API we've been querying up until now was created: the Guillotine library is the answer. The Guillotine library analyzes all the content in your applications and generates an API from that. It' s an optional library that comes preconfigured with the headless starter that we used xref:apps#_projects_and_starters[back when we first created our app in a previous {document}]. Guillotine provides direct, typed, and documented access to content within your site.
 
 If you're familiar with GraphQL, you might have noticed that we have not performed any mutations yet. The reason for that is simple: Guillotine only exposes the read-only part of the Enonic Content API, so mutations are not available.
 

--- a/docs/headless-api.adoc
+++ b/docs/headless-api.adoc
@@ -116,9 +116,11 @@ The result of this query should list all the {content-type-1}s you created previ
 }
 ----
 
-Neat! Next, let's try a slightly more complicated query. In this one,  we'll also get the data inside the content nodes and extract their names and alias fields.
+Neat! Next, let's try a slightly more complicated query. In this one,  we'll also get the data inside the content nodes and extract their names and alias fields. Because all content shares the `displayName` property, you can query for it without specifying what type it belongs to. However, to get fields that exist on the {content-type-1-capitalized} type, you need to specifically tell GraphQL what type you're looking for via _inline fragments_. Inline fragments start with `... on` and then specify the content type you want.
 
-.A GraphQL query that fetches all {content-type-1}s and their data
+TIP: Learn more about inline fragments at https://graphql.org/learn/queries/#inline-fragments[the GraphQL documentation's _Inline Fragments_ section]
+
+.A GraphQL query that fetches all {content-type-1}s and their data using inline fragments
 [source, GraphQL,{subs}]
 ----
 {
@@ -126,7 +128,7 @@ Neat! Next, let's try a slightly more complicated query. In this one,  we'll als
     getChildren(key: "${site}/{content-type-1}s/")
     {
       displayName
-      ... on {project-name-query}_{content-type-1-capitalized} {
+      ... on {project-name-query}_{content-type-1-capitalized} { <--.-->
         data {
           name
           about
@@ -136,6 +138,8 @@ Neat! Next, let's try a slightly more complicated query. In this one,  we'll als
   }
 }
 ----
+
+<.>   This inline fragment lets us extract extra data from content of the {content-type-1-capitalized} type.
 
 Execute this and your response should look a little something like this:
 

--- a/docs/sandboxes.adoc
+++ b/docs/sandboxes.adoc
@@ -80,7 +80,7 @@ GLOBAL OPTIONS:
 
 == Sandboxes
 
-When talking about _sandboxes_, we're actually talking about local instances of Enonic XP. Having a local (and running) instance of XP is essential for an effective development workflow.
+When talking about _sandboxes_, we're actually talking about local instances of Enonic XP. Having a local (and running) instance of XP is essential for an effective development workflow. Using sandboxes allows you to run different versions of XP because each sandbox has an associated XP version. In this guide, though, we'll stick to using a single sandbox.
 
 Let's create a new sandbox by using the CLI. When you create a new sandbox, the CLI will present you with a few questions for configuring the sandbox, such as the sandbox name. To respond to a question, type in the desired response and press kbd:[enter].
 

--- a/docs/sandboxes.adoc
+++ b/docs/sandboxes.adoc
@@ -165,13 +165,13 @@ NOTE: To stop your sandbox, press kbd:[ctrl-c] in the terminal hosting the proce
 If you have problems booting the sandbox, it may be that one or more of the ports used by XP are already in use. The command should warn you if something doesn't work right. It'll do this in one of two ways:
 
 . If the CLI checks for the availability of some ports when starting up. If one of these ports isn't available, the CLI will abort with a message like this:
-
++
 ----
 Port 8080 is not available, stop the app using it first!
 ----
 
 . For ports where the CLI doesn't check for availability before starting, you might get an exception in the boot log. This is usually identifiable by a printed stack trace in your logs. Here's an example from what happens if port 4848 isn't available. The `[...]` replaces most of the stack trace for legibility reasons.
-
++
 ----
 2021-04-06 11:24:01,168 ERROR c.e.xp.web.jetty.impl.JettyActivator - bundle com.enonic.xp.web.jetty:7.6.1 (80)[com.enonic.xp.web.jetty.impl.JettyActivator(171)] : The activate method has thrown an exception
 org.apache.felix.log.LogException: java.io.IOException: Failed to bind to 0.0.0.0/0.0.0.0:4848

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -62,14 +62,14 @@ Now, we'll install the Enonic CLI via the package manager we just set up. The CL
 
 [NOTE]
 ====
-While we heavily recommend using a package manager, you can also download and install the executables manually if you prefer. To do that, find your desired version and operating system https://repo.enonic.com/public/com/enonic/cli/enonic/[here], download the files you need, and install them as you would any other binary files on your system.
+While we heavily recommend using a package manager, you can also download and install the executables manually if you prefer. To do that, visit the https://repo.enonic.com/public/com/enonic/cli/enonic/[the Enonic CLI public repo], download the files that correspond to the desired CLI version and your OS, and install them as you would any other binary files on your system.
 ====
 
-Follow the instructions for your specific operating system below. When you have installed the CLI, verify that it's working by running
+=== Installation
 
-  enonic version
+The steps differ depending on your OS. Follow the steps below that best match your OS.
 
-=== macOS
+==== macOS
 
 From your terminal:
 
@@ -83,7 +83,7 @@ From your terminal:
 
 To upgrade to newer versions of enonic CLI when they become available, run the command `brew upgrade enonic`
 
-=== Windows
+==== Windows
 
 From a Powershell terminal:
 
@@ -97,7 +97,7 @@ From a Powershell terminal:
 
 To upgrade to newer versions of enonic CLI when they become available, run the command `scoop update enonic`
 
-=== Linux
+==== Linux
 
 From your terminal, run the following command:
 
@@ -105,21 +105,24 @@ From your terminal, run the following command:
 
 Snap automatically keeps your snaps updated. To manually force an update, run the command `sudo snap refresh enonic`
 
+=== Verification
+
+When you have installed the CLI, verify that it's working by running
+
+  enonic version
 
 == Git
 
 Git is a free and open source _distributed version control system_. Later on in this tutorial, we will create new Enonic development projects using _starters_. The Enonic CLI uses Git to download these starters and to prepare the files for your project locally.
 
-To install Git, follow the notes for your operating system below.
-
-Once you have installed Git, you can verify that it's working correctly by running the following command:
-
-    git version
-
 TIP: Want to learn more about Git? Check out https://guides.github.com/introduction/git-handbook/[this useful Git handbook by Github].
 
 
-=== macOS
+=== Installation
+
+To install Git, follow the notes for your operating system below.
+
+==== macOS
 
 NOTE: Apple maintains its own fork of Git. If you have XCode installed, you already have Git installed too.
 
@@ -127,17 +130,23 @@ To install Git via Homebrew, run this command:
 
     brew install git
 
-=== Windows
+==== Windows
 
 To install Git using Scoop, run the following command from Powershell:
 
     scoop install git
 
-=== Linux
+==== Linux
 
 To install Git with Snapcraft, run the following command:
 
    sudo snap install git
+
+=== Verification
+
+Once you have installed Git, you can verify that it's working correctly by running the following command:
+
+    git version
 
 
 == Text editors

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -149,15 +149,15 @@ Once you have installed Git, you can verify that it's working correctly by runni
     git version
 
 
-== Text editors
+== Source-code editors
 
-Text editors (or just _editors_ for short) are applications that are designed primarily for editing plain text and often specifically for working with code. They are therefore commonly used for programming. Note that text editors are different from _word processors_ such as Microsoft Word, which are not suited to programming.
+Source-code editors (also known as _text editors_ or just _editors_ for short) are applications designed primarily for editing plain text and often specifically for working with code. They are therefore commonly used for programming.
 
 If you do not yet have an editor you like, follow the steps below to get started with one.
 
 === Download Visual Studio Code
 
-https://code.visualstudio.com/[Visual Studio Code] (often shortened to _VS Code_ or simply _Code_) is one of the most popular text editors around at the moment. It's free, open source, and available on all major platforms.
+https://code.visualstudio.com/[Visual Studio Code] (often shortened to _VS Code_ or simply _Code_) is one of the most popular source-code editors around at the moment. It's free, open source, and available on all major platforms.
 
 You can navigate to the https://code.visualstudio.com/Download[download page] and download and install the version matching your operating system. Alternatively, if you're getting into this whole package manager business, it's also available in all package managers listed above. The install instructions will vary, though, so you'll have to figure that out on your own.
 

--- a/docs/setup.adoc
+++ b/docs/setup.adoc
@@ -62,7 +62,7 @@ Now, we'll install the Enonic CLI via the package manager we just set up. The CL
 
 [NOTE]
 ====
-While we heavily recommend using a package manager, you can also download and install the executables manually if you prefer. To do that, visit the https://repo.enonic.com/public/com/enonic/cli/enonic/[the Enonic CLI public repo], download the files that correspond to the desired CLI version and your OS, and install them as you would any other binary files on your system.
+While we heavily recommend using a package manager, you can also download and install the executables manually if you prefer. To do that, visit the https://repo.enonic.com/public/com/enonic/cli/enonic/[the Enonic CLI public repo], download the files that correspond to the desired CLI version and your OS, and install them as you would any other binary files on your system. There is also https://repo.enonic.com/public/com/enonic/cli/installer/cli-windows/1.0.0/cli-windows-1.0.0.exe[a Windows installer for the CLI] available.
 ====
 
 === Installation


### PR DESCRIPTION
This PR includes most of the changes proposed by ASE for the first few chapters of the getting started guide. The changes are listed below.

## Changes contained

Alan has reviewed the document thus far. Here are some things to fix:

## Chapter 1: env setup

- [x] Maybe add a link to Windows installer as well somewhere under “The Enonic CLI”?
https://repo.enonic.com/public/com/enonic/cli/installer/cli-windows/1.0.0/cli-windows-1.0.0.exe
- [x] Maybe recommend running “enonic version” and “git version” AFTER installation instructions, so that it goes in a natural order?
- [x] I suggest renaming “text editors” to “code editors” everywhere, since that’s how they are usually called. Then you don’t really need to specify that it’s not the same as Word.

Note: wikipedia uses 'source-code editors'.

## Chapter 2: Sandboxes

- [x] I’d clarify a bit that one can set up as many sandboxes as one wants to run different versions of Enonic XP. Right now it’s not obvious (but maybe not so important for this guide?)
- [x] Broken numbering under Troubleshooting (two “1.“)

## Chapter 3: App dev

- [x] “The tasks and examples in this chapter build on work done…“. Maybe replace “build on” with smith else, since we typically use “build” referring to build process. With “…are based on…” for example.

- [x] “If you need to start your sandbox and your current working directory is an XP project directory, then the projects assigned sandbox will be started automatically.”
This is very confusingly worded. And I don’t think it’s worth mentioning either. What we need to mention is that each project gets linked to one and only one sandbox upon its creation (but this can be changed with project sandbox command)

## Chapter 4: Content
- [x] add a link to the “Content Studio” own docs the first time you mention it?
- [x] This sentence doesn’t look right “So with your sandbox up and running, and navigate to Content Studio. ”
- [x] Double “you’s”: “You should be met with an empty studio that tells you you are “wasting this space”"
- [x] I think it’s important to specify (maybe under IMPORTANT section even) that if an app containing content types is stopped or removed or unlinked from the site, the content will no longer be renderable and even preview will give errors.

## Chapter 5: Headless

- [x] When you describe a query which adds more fields to displayName, maybe we should explain why we have to cast the data fields (because displayName is a common field for all content types while data fields are specific)
- [x] Two “back’s”: “The Guillotine library analyzes all the content in your applications and generates an API from that. It’ s an optional library that comes preconfigured with the headless starter that we used back back when we first created our app in a previous chapter.”
- [x] Replace “jcenter” with “mavenCentral” (jcenter is deprecated)
- [x] Typo “reuqests”

### Removed

~~- [ ] You don’t need “apply plugin…” if you already have it under “plugins”~~
I'll leave this as is because it's what the starter does by default. However, if it can be removed, maybe it'd be worth updating the starter?